### PR TITLE
chore: bump minimum HASS version

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,17 +19,20 @@ jobs:
     name: "Ruff"
     runs-on: "ubuntu-latest"
     steps:
-        - name: "Checkout the repository"
-          uses: "actions/checkout@v6.0.2"
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
 
-        - name: "Set up Python"
-          uses: actions/setup-python@v6.2.0
-          with:
-            python-version: "3.11"
-            cache: "pip"
+      - name: "Set up Python"
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
 
-        - name: "Install requirements"
-          run: python3 -m pip install -r requirements.txt
+      - name: "Upgrade pip"
+        run: python3 -m pip install --upgrade pip
 
-        - name: "Run"
-          run: python3 -m ruff check .
+      - name: "Install requirements"
+        run: python3 -m pip install -r requirements.txt
+
+      - name: "Run"
+        run: python3 -m ruff check .

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "Emerald HWS",
   "filename": "emeraldenergy.zip",
   "hide_default_branch": true,
-  "homeassistant": "2024.1.6",
+  "homeassistant": "2025.8.0",
   "render_readme": true,
   "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.10.1
-homeassistant==2024.1.6
+homeassistant>=2025.8.0
 pip>=21.0,<26.1
 ruff==0.15.1
 emerald_hws==0.0.25


### PR DESCRIPTION
## Summary by Sourcery

Update development tooling to target newer Home Assistant and Python versions.

Build:
- Bump Home Assistant dependency to 2025.8.0 in requirements.

CI:
- Update lint workflow to use Python 3.12 and fix step indentation.