### PR TITLE
feat: add in "tank capacity" figure (like the app has)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ To determine if the water heater is actively heating (not just turned on):
 {{ state_attr('water_heater.emerald_<serial>', "is_heating") }}
 ```
 
+To read a derived estimate of remaining hot-water tank capacity as a percentage (clamped to 0–100). This is a local calculation from the current and target temperatures — the API does not return it directly, so treat it as indicative only:
+```yaml
+{{ state_attr('water_heater.emerald_<serial>', "tank_capacity_percent") }}
+```
+
+The same value rounded to the nearest 20%, matching the capacity figure shown in the official Emerald app:
+```yaml
+{{ state_attr('water_heater.emerald_<serial>', "tank_capacity_percent_rounded") }}
+```
+
 ## Troubleshooting
 
 ### Login Issues

--- a/custom_components/emeraldenergy/water_heater.py
+++ b/custom_components/emeraldenergy/water_heater.py
@@ -1,28 +1,28 @@
 """Implementation of the Water Heater type for Emerald HWS."""
 
-from .const import (
-    DOMAIN,
-)
-
 import logging
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
 from homeassistant.components.water_heater import (
-    WaterHeaterEntityFeature,
-    WaterHeaterEntity,
+    STATE_ECO,
     STATE_HEAT_PUMP,
     STATE_OFF,
     STATE_PERFORMANCE,
-    STATE_ECO,
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
 )
 from homeassistant.const import (
-    CONF_USERNAME,
     CONF_PASSWORD,
-    UnitOfTemperature,
+    CONF_USERNAME,
     PRECISION_WHOLE,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -148,6 +148,9 @@ class EmeraldWaterHeater(WaterHeaterEntity):
         current = self._current_temperature
         target = self._target_temperature
         if current is not None and target is not None:
+            # Tank capacity is not returned by the API; derive it the same way the
+            # Emerald app does: each degree below target costs ~2.3% capacity, and
+            # the app displays the result snapped to the nearest 20% step.
             raw = 100 - 2.3 * (target - current)
             clamped = max(0.0, min(100.0, raw))
             attrs["tank_capacity_percent"] = int(round(clamped))

--- a/custom_components/emeraldenergy/water_heater.py
+++ b/custom_components/emeraldenergy/water_heater.py
@@ -141,9 +141,18 @@ class EmeraldWaterHeater(WaterHeaterEntity):
 
     @property
     def extra_state_attributes(self):
-        """Return the isHeating property as an attribute."""
+        """Return additional state attributes."""
         attrs = super().extra_state_attributes or {}
         attrs["is_heating"] = self._is_heating
+
+        current = self._current_temperature
+        target = self._target_temperature
+        if current is not None and target is not None:
+            raw = 100 - 2.3 * (target - current)
+            clamped = max(0.0, min(100.0, raw))
+            attrs["tank_capacity_percent"] = int(round(clamped))
+            attrs["tank_capacity_percent_rounded"] = int(round(clamped / 20) * 20)
+
         return attrs
 
     def modeToOpState(self, mode):


### PR DESCRIPTION
## Summary by Sourcery

Expose additional water heater state attributes estimating remaining hot-water tank capacity based on current and target temperatures.

New Features:
- Add derived tank_capacity_percent attribute representing estimated remaining tank capacity clamped between 0–100%.
- Add tank_capacity_percent_rounded attribute providing tank capacity rounded to the nearest 20% to mirror the official app display.

Documentation:
- Document how to access and interpret the new tank capacity attributes in Home Assistant templates, including the rounded value matching the Emerald app.