### PR TITLE
fix: log spam caused by create_task threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__
 .coverage
 .vscode
 coverage.xml
-
+.DS_Store
 
 # Home Assistant configuration
 config/*

--- a/custom_components/emeraldenergy/__init__.py
+++ b/custom_components/emeraldenergy/__init__.py
@@ -3,19 +3,20 @@
 from __future__ import annotations
 
 import logging
+
+from emerald_hws.emeraldhws import EmeraldHWS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from emerald_hws.emeraldhws import EmeraldHWS
 
 from .const import (
-    DOMAIN,
     CONF_CONNECTION_TIMEOUT,
     CONF_HEALTH_CHECK,
+    CONF_PASSWORD,
+    CONF_USERNAME,
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_HEALTH_CHECK,
-    CONF_USERNAME,
-    CONF_PASSWORD,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,8 +55,8 @@ class CallbackDispatcher:
         for callback in self._callbacks:
             try:
                 callback()
-            except Exception as e:
-                _LOGGER.error(f"Error in callback: {e}")
+            except Exception:
+                _LOGGER.exception("Error in callback %r", callback)
 
     def __call__(self):
         """Make the dispatcher callable."""

--- a/custom_components/emeraldenergy/sensor.py
+++ b/custom_components/emeraldenergy/sensor.py
@@ -117,8 +117,19 @@ class EmeraldEnergySensor(SensorEntity):
         return self._last_reset
 
     def update_callback(self):
-        """Schedules an update within HASS when data changes."""
+        """Schedules an update within HASS when data changes (module thread)."""
         _LOGGER.debug(f"Energy sensor callback for {self._attr_name}")
+        if self.hass is None:
+            # The emerald_hws MQTT thread can fire callbacks before the entity
+            # is added to HASS (or after removal). schedule_update_ha_state is
+            # thread-safe, but with self.hass is None it would raise
+            # "'NoneType' object has no attribute 'create_task'".
+            _LOGGER.debug(
+                "Dropping callback for %s; hass not set (entity not added yet "
+                "or already removed)",
+                self._attr_name,
+            )
+            return
         self.schedule_update_ha_state(True)
 
     def update_energy_value(self):

--- a/custom_components/emeraldenergy/water_heater.py
+++ b/custom_components/emeraldenergy/water_heater.py
@@ -203,8 +203,19 @@ class EmeraldWaterHeater(WaterHeaterEntity):
         # await self._emerald_hws.turnOff(self._hws_uuid)
 
     def update_callback(self):
-        """Schedules an update within HASS."""
+        """Schedules an update within HASS (called from the module's thread)."""
         _LOGGER.info("emeraldhws: callback called")
+        if self.hass is None:
+            # The emerald_hws MQTT thread can fire callbacks before the entity
+            # is added to HASS (or after removal). schedule_update_ha_state is
+            # thread-safe, but with self.hass is None it would raise
+            # "'NoneType' object has no attribute 'create_task'".
+            _LOGGER.debug(
+                "Dropping callback for %s; hass not set (entity not added yet "
+                "or already removed)",
+                self._name,
+            )
+            return
         self.schedule_update_ha_state(True)
 
     def update(self):


### PR DESCRIPTION
## Summary by Sourcery

Prevent exceptions and log spam from entity callbacks invoked before Home Assistant has attached the entity, and improve error logging for callback failures.

Bug Fixes:
- Guard entity update callbacks against running when the Home Assistant instance is not yet attached, avoiding NoneType create_task errors and associated log spam.

Enhancements:
- Switch callback error handling to log full exceptions with stack traces instead of only the error message.