### PR TITLE
chore: version bump, better guard

### DIFF
--- a/custom_components/emeraldenergy/__init__.py
+++ b/custom_components/emeraldenergy/__init__.py
@@ -117,8 +117,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     except Exception:
+        _LOGGER.warning(
+            "Emerald HWS setup failed after the connection was established; "
+            "disconnecting so the retry does not leave MQTT threads behind"
+        )
         hass.data[DOMAIN].pop(entry.entry_id, None)
-        await hass.async_add_executor_job(emerald_hws_instance.disconnect)
+        try:
+            await hass.async_add_executor_job(emerald_hws_instance.disconnect)
+        except Exception:
+            # Cleanup must never replace the failure that triggered it, so this is
+            # logged and swallowed; the bare raise below re-raises the real cause.
+            _LOGGER.exception(
+                "Failed to disconnect the Emerald HWS instance during cleanup"
+            )
         raise
 
     return True

--- a/custom_components/emeraldenergy/__init__.py
+++ b/custom_components/emeraldenergy/__init__.py
@@ -116,15 +116,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    except Exception:
+    except BaseException:
+        # BaseException, not Exception: HA cancels in-flight setup tasks on shutdown
+        # and when a reload races setup, and CancelledError would otherwise skip the
+        # disconnect below and strand the MQTT threads. Nothing is swallowed -- the
+        # bare raise at the end re-raises whatever arrived, cancellation included.
         _LOGGER.warning(
-            "Emerald HWS setup failed after the connection was established; "
-            "disconnecting so the retry does not leave MQTT threads behind"
+            "Emerald HWS setup did not complete after the connection was "
+            "established; disconnecting so nothing is left holding MQTT threads"
         )
         # Nothing in this block may raise: hass.data[DOMAIN] is set up above, but a
         # subscript here would mask the real failure if that ever stopped holding.
         hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
         try:
+            # The executor job is submitted as soon as this is called, so disconnect
+            # still runs on its thread even if cancellation interrupts the await.
             await hass.async_add_executor_job(emerald_hws_instance.disconnect)
         except Exception:
             # Cleanup must never replace the failure that triggered it, so this is

--- a/custom_components/emeraldenergy/__init__.py
+++ b/custom_components/emeraldenergy/__init__.py
@@ -79,20 +79,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         emerald_hws_instance = await hass.async_add_executor_job(
             _create_and_connect, entry.data
         )
-
-        # Create and store callback dispatcher for this instance
-        callback_dispatcher = CallbackDispatcher()
-        emerald_hws_instance.replaceCallback(callback_dispatcher)
-
-        # Store both the instance and dispatcher for platforms to access
-        hass.data[DOMAIN][entry.entry_id] = {
-            "instance": emerald_hws_instance,
-            "dispatcher": callback_dispatcher,
-        }
-        _LOGGER.info(
-            "Emerald HWS API instance and callback dispatcher created and stored"
-        )
-
     except Exception as err:
         # emerald_hws raises bare Exceptions, and its awsiotsdk/awscrt stack can fail
         # in ways only the traceback identifies, so log the full trace rather than
@@ -113,7 +99,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Failed to connect to the Emerald cloud: {err}"
         ) from err
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # Past this point the instance holds a live MQTT connection with its own threads
+    # and timers, so anything that fails has to hand it back before HA retries setup.
+    try:
+        # Create and store callback dispatcher for this instance
+        callback_dispatcher = CallbackDispatcher()
+        emerald_hws_instance.replaceCallback(callback_dispatcher)
+
+        # Store both the instance and dispatcher for platforms to access
+        hass.data[DOMAIN][entry.entry_id] = {
+            "instance": emerald_hws_instance,
+            "dispatcher": callback_dispatcher,
+        }
+        _LOGGER.info(
+            "Emerald HWS API instance and callback dispatcher created and stored"
+        )
+
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except Exception:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        await hass.async_add_executor_job(emerald_hws_instance.disconnect)
+        raise
 
     return True
 

--- a/custom_components/emeraldenergy/__init__.py
+++ b/custom_components/emeraldenergy/__init__.py
@@ -121,7 +121,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Emerald HWS setup failed after the connection was established; "
             "disconnecting so the retry does not leave MQTT threads behind"
         )
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        # Nothing in this block may raise: hass.data[DOMAIN] is set up above, but a
+        # subscript here would mask the real failure if that ever stopped holding.
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
         try:
             await hass.async_add_executor_job(emerald_hws_instance.disconnect)
         except Exception:

--- a/custom_components/emeraldenergy/helpers.py
+++ b/custom_components/emeraldenergy/helpers.py
@@ -18,13 +18,34 @@ from .const import (
 )
 
 
-# A compiled awscrt function rejecting its own wrapper's call, e.g.
-# "function takes exactly 43 arguments (45 given)". This is the C-extension
-# wording; a pure-Python arity error reads "takes N positional arguments but M
-# were given" instead, so this does not match ordinary bugs in our own code.
+# A compiled function rejecting its caller's argument count, e.g. "function takes
+# exactly 43 arguments (45 given)". Both wordings below come from CPython's C API
+# (PyArg_ParseTuple and argument clinic respectively); a pure-Python arity error
+# reads "takes N positional arguments but M were given" instead. Small counts are
+# spelled as words by METH_NOARGS/METH_O, hence "no" and "one".
+#
+# Matching this message is necessary but NOT sufficient: every compiled extension
+# raises it, so an ordinary bug elsewhere in the stack looks identical. Callers
+# must also confirm the frame it came from with _raised_inside_awscrt().
 _NATIVE_ARITY_ERROR = re.compile(
-    r"takes (?:exactly |at most |at least )?\d+ arguments? \(\d+ given\)"
+    r"takes (?:exactly |at most |at least )?(?:\d+|no|one) arguments? \(\d+ given\)"
+    r"|expected (?:exactly |at most |at least )?\d+ arguments?, got \d+"
 )
+
+
+def _raised_inside_awscrt(err: BaseException) -> bool:
+    """Report whether any frame in err's traceback belongs to the awscrt package.
+
+    Walks the raw traceback rather than using traceback.extract_tb, which reads the
+    source files off disk through linecache -- unwanted work on a failure path.
+    """
+    tb = err.__traceback__
+    while tb is not None:
+        parts = tb.tb_frame.f_code.co_filename.replace("\\", "/").split("/")
+        if "awscrt" in parts:
+            return True
+        tb = tb.tb_next
+    return False
 
 
 def is_awscrt_straddle_error(err: BaseException) -> bool:
@@ -44,8 +65,10 @@ def is_awscrt_straddle_error(err: BaseException) -> bool:
     the two halves meet inside connect().
 
     Two ways that surfaces, both from awscrt's IoT usage-metrics feature:
-      - AttributeError on _certificate_source, a slot only awscrt >=0.35.0's
-        awscrt.io declares but which >=0.35.0's metrics code always reads.
+      - AttributeError on _certificate_source, an attribute the newer awscrt.io
+        sets on ClientTlsContext and the newer metrics code reads back, and which
+        is therefore missing whenever the ClientTlsContext was built by the older
+        awscrt.io still sitting in sys.modules.
       - TypeError on argument count, from the two metrics arguments that awscrt
         0.32.2 added to the native mqtt5_client_new binding.
 
@@ -59,9 +82,20 @@ def is_awscrt_straddle_error(err: BaseException) -> bool:
         message = str(err)
         if isinstance(err, AttributeError) and "_certificate_source" in message:
             return True
-        if isinstance(err, TypeError) and _NATIVE_ARITY_ERROR.search(message):
+        if (
+            isinstance(err, TypeError)
+            and _NATIVE_ARITY_ERROR.search(message)
+            and _raised_inside_awscrt(err)
+        ):
             return True
-        err = err.__cause__ or err.__context__
+        if err.__cause__ is not None:
+            err = err.__cause__
+        elif err.__suppress_context__:
+            # "raise X from None": the context is deliberately hidden, so whatever
+            # is behind it is not what this failure is about.
+            break
+        else:
+            err = err.__context__
     return False
 
 

--- a/custom_components/emeraldenergy/helpers.py
+++ b/custom_components/emeraldenergy/helpers.py
@@ -49,7 +49,7 @@ def _raised_inside_awscrt(err: BaseException) -> bool:
     while tb is not None:
         module = tb.tb_frame.f_globals.get("__name__")
         if module is not None:
-            if module.split(".")[0] == "awscrt":
+            if module == "awscrt" or module.startswith("awscrt."):
                 return True
         elif "awscrt" in PurePath(tb.tb_frame.f_code.co_filename).parts:
             return True

--- a/custom_components/emeraldenergy/helpers.py
+++ b/custom_components/emeraldenergy/helpers.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from pathlib import PurePath
 from typing import Any
 
 from emerald_hws.emeraldhws import EmeraldHWS
@@ -38,14 +39,44 @@ def _raised_inside_awscrt(err: BaseException) -> bool:
 
     Walks the raw traceback rather than using traceback.extract_tb, which reads the
     source files off disk through linecache -- unwanted work on a failure path.
+
+    Frames are identified by module name, falling back to the file path for the rare
+    frame whose globals carry no __name__ (exec'd or embedded code). Missing a real
+    awscrt frame would put setup back into an endless retry loop, so the fallback is
+    worth the extra line.
     """
     tb = err.__traceback__
     while tb is not None:
-        parts = tb.tb_frame.f_code.co_filename.replace("\\", "/").split("/")
-        if "awscrt" in parts:
+        module = tb.tb_frame.f_globals.get("__name__")
+        if module is not None:
+            if module.split(".")[0] == "awscrt":
+                return True
+        elif "awscrt" in PurePath(tb.tb_frame.f_code.co_filename).parts:
             return True
         tb = tb.tb_next
     return False
+
+
+def _exception_chain(err: BaseException) -> Iterator[BaseException]:
+    """Yield err and every exception behind it, outermost first.
+
+    The walk order is: prefer __cause__ ("raise X from Y", an explicit statement of
+    what really went wrong); otherwise stop at a suppressed context ("raise X from
+    None" deliberately hides it); otherwise follow __context__, the error that was
+    being handled when this one was raised. A chain that loops back on itself ends
+    the walk. The caller holds a reference to the head throughout, so no link can be
+    collected mid-walk and have its id() reused.
+    """
+    seen: set[int] = set()
+    while err is not None and id(err) not in seen:
+        seen.add(id(err))
+        yield err
+        if err.__cause__ is not None:
+            err = err.__cause__
+        elif err.__suppress_context__:
+            return
+        else:
+            err = err.__context__
 
 
 def is_awscrt_straddle_error(err: BaseException) -> bool:
@@ -76,26 +107,16 @@ def is_awscrt_straddle_error(err: BaseException) -> bool:
     of the process, so only restarting Home Assistant can clear it -- which is why
     this is reported as a permanent error rather than left to HA's retry backoff.
     """
-    seen: set[int] = set()
-    while err is not None and id(err) not in seen:
-        seen.add(id(err))
-        message = str(err)
-        if isinstance(err, AttributeError) and "_certificate_source" in message:
+    for link in _exception_chain(err):
+        message = str(link)
+        if isinstance(link, AttributeError) and "_certificate_source" in message:
             return True
         if (
-            isinstance(err, TypeError)
+            isinstance(link, TypeError)
             and _NATIVE_ARITY_ERROR.search(message)
-            and _raised_inside_awscrt(err)
+            and _raised_inside_awscrt(link)
         ):
             return True
-        if err.__cause__ is not None:
-            err = err.__cause__
-        elif err.__suppress_context__:
-            # "raise X from None": the context is deliberately hidden, so whatever
-            # is behind it is not what this failure is about.
-            break
-        else:
-            err = err.__context__
     return False
 
 

--- a/custom_components/emeraldenergy/manifest.json
+++ b/custom_components/emeraldenergy/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/ross-w/emerald-hws-ha/issues",
   "loggers": ["emerald_hws"],
-  "requirements": ["emerald_hws==0.0.29"],
+  "requirements": ["emerald_hws==0.0.30"],
   "ssdp": [],
   "version": "0.0.0",
   "zeroconf": []

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.12.0
 homeassistant>=2025.8.0
 pip>=26.1.2,<26.2
 ruff==0.16.0
-emerald_hws==0.0.29
+emerald_hws==0.0.30


### PR DESCRIPTION
## Summary by Sourcery

Guard Home Assistant setup against partially initialized Emerald HWS connections and improve detection of awscrt version-straddle errors while updating to the latest emerald_hws library version.

Bug Fixes:
- Ensure Emerald HWS MQTT connections are cleanly disconnected and state cleared if Home Assistant setup fails or is cancelled after connection is established.
- Tighten identification of awscrt version-straddle errors to avoid misclassifying unrelated TypeErrors.

Enhancements:
- Refine awscrt arity-error pattern matching and add traceback- and exception-chain helpers to more accurately locate awscrt-originated failures.

Build:
- Bump emerald_hws dependency from 0.0.29 to 0.0.30 in both the integration manifest and project requirements.