### PR TITLE
Fix water heater/sensor device grouping and None-in-registry risk

### DIFF
--- a/custom_components/emeraldenergy/sensor.py
+++ b/custom_components/emeraldenergy/sensor.py
@@ -89,8 +89,12 @@ class EmeraldEnergySensor(SensorEntity):
 
         # Get device info for proper integration
         gi = emerald_hws_instance.getInfo(hws_uuid)
-        self._serial_number = gi.get("serial_number")
-        self._brand = gi.get("brand", "Emerald")
+        # Fall back rather than leaving these None: they land in the device
+        # registry, which is last-write-wins across this entity and the water
+        # heater sharing the same device -- a None from either would blank out
+        # a value the other successfully set.
+        self._serial_number = gi.get("serial_number") or hws_uuid
+        self._brand = gi.get("brand") or "Emerald"
 
         # Set up sensor properties
         self._attr_name = f"{self._brand} {self._serial_number} Daily Energy"

--- a/custom_components/emeraldenergy/water_heater.py
+++ b/custom_components/emeraldenergy/water_heater.py
@@ -104,9 +104,22 @@ class EmeraldWaterHeater(WaterHeaterEntity):
         self._callback_dispatcher = callback_dispatcher
         gi = emerald_hws_instance.getInfo(hws_uuid)
         status = emerald_hws_instance.getFullStatus(hws_uuid)
-        self._serial_number = gi.get("serial_number")
-        self._brand = gi.get("brand")
+        # Fall back rather than leaving these None: they land in the device
+        # registry, which is last-write-wins across this entity and the energy
+        # sensor sharing the same device -- a None from either would blank out
+        # a value the other successfully set.
+        self._serial_number = gi.get("serial_number") or hws_uuid
+        self._brand = gi.get("brand") or "Emerald"
         self._name = f"{self._brand} {self._serial_number}"
+        # Same identifiers as sensor.py's device_info so both entities group
+        # under one device instead of two.
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, hws_uuid)},
+            "name": self._name,
+            "manufacturer": self._brand,
+            "model": "Hot Water System",
+            "serial_number": self._serial_number,
+        }
         self._current_temperature = status.get("last_state").get("temp_current")
         self._target_temperature = status.get("last_state").get("temp_set")
         self._running = emerald_hws_instance.isOn(hws_uuid)


### PR DESCRIPTION
Split out of #240 per review feedback.

## Summary

- The water heater entity was missing `device_info` entirely, so it never grouped with its energy sensor despite `sensor.py`'s comment claiming they group. Added the matching `device_info` dict (same `identifiers` key: `(DOMAIN, hws_uuid)`).
- Both entities built `serial_number`/`brand` from the Emerald API with no fallback for a missing field. `device_info` is last-write-wins in HA's device registry across entities sharing a device, so a `None` from either entity could blank out a value the other successfully set. Falls back to `hws_uuid` / `"Emerald"` respectively -- matching what `sensor.py` already did for `brand`, extended to `serial_number` and to the water heater.

No new entities, no config/API changes -- existing installs get correctly-grouped devices and stop risking a blanked-out name/serial in the registry.

## Test plan

- `python3 -m py_compile` on both changed files
- Manual read-through: confirmed the two `device_info` dicts now use identical `identifiers`

## Summary by Sourcery

Ensure Emerald water heater and energy sensor entities share one correctly populated Home Assistant device.

Bug Fixes:
- Prevent missing Emerald metadata from clearing shared Home Assistant device registry values by applying stable serial-number and brand fallbacks.
- Group water heater entities with their corresponding energy sensors under the same Home Assistant device.