### PR TITLE
Extract CallbackDrivenEntityMixin and device_info_for (no behavior change)

### DIFF
--- a/custom_components/emeraldenergy/helpers.py
+++ b/custom_components/emeraldenergy/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Iterator, Mapping
 from pathlib import PurePath
@@ -16,7 +17,10 @@ from .const import (
     CONF_USERNAME,
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_HEALTH_CHECK,
+    DOMAIN,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # A compiled function rejecting its caller's argument count, e.g. "function takes
@@ -118,6 +122,55 @@ def is_awscrt_straddle_error(err: BaseException) -> bool:
         ):
             return True
     return False
+
+
+def device_info_for(hws_uuid: str, brand: str, serial_number: str) -> dict[str, Any]:
+    """Build the shared device_info dict for one HWS.
+
+    Same identifiers on both entities make them group under one device in HA.
+    """
+    return {
+        "identifiers": {(DOMAIN, hws_uuid)},
+        "name": f"{brand} {serial_number}",
+        "manufacturer": brand,
+        "model": "Hot Water System",
+        "serial_number": serial_number,
+    }
+
+
+class CallbackDrivenEntityMixin:
+    """Lifecycle shared by every entity registered with a CallbackDispatcher.
+
+    Both entity classes in sensor.py/water_heater.py reimplemented this
+    identically; the only thing that actually differs between them is what
+    update() does. List this mixin first in the entity's bases and set
+    self._hass/self._callback_dispatcher in __init__ as usual.
+    """
+
+    def update_callback(self) -> None:
+        """Schedule a state update when the dispatcher fires (module thread)."""
+        _LOGGER.debug("Callback for %s", self.name)
+        if self.hass is None:
+            # The emerald_hws MQTT thread can fire callbacks before the entity
+            # is added to HASS (or after removal). schedule_update_ha_state is
+            # thread-safe, but with self.hass is None it would raise
+            # "'NoneType' object has no attribute 'create_task'".
+            _LOGGER.debug(
+                "Dropping callback for %s; hass not set (entity not added yet "
+                "or already removed)",
+                self.name,
+            )
+            return
+        self.schedule_update_ha_state(True)
+
+    async def async_update(self) -> None:
+        """Update the entity state asynchronously."""
+        await self._hass.async_add_executor_job(self.update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up when entity is removed from Home Assistant."""
+        self._callback_dispatcher.unregister_callback(self.update_callback)
+        await super().async_will_remove_from_hass()
 
 
 def create_hws(config: Mapping[str, Any]) -> EmeraldHWS:

--- a/custom_components/emeraldenergy/sensor.py
+++ b/custom_components/emeraldenergy/sensor.py
@@ -89,8 +89,12 @@ class EmeraldEnergySensor(SensorEntity):
 
         # Get device info for proper integration
         gi = emerald_hws_instance.getInfo(hws_uuid)
-        self._serial_number = gi.get("serial_number")
-        self._brand = gi.get("brand", "Emerald")
+        # Fall back rather than leaving these None: they land in the device
+        # registry, which is last-write-wins across this entity and the water
+        # heater sharing the same device -- a None from either would blank out
+        # a value the other successfully set.
+        self._serial_number = gi.get("serial_number") or hws_uuid
+        self._brand = gi.get("brand") or "Emerald"
 
         # Set up sensor properties
         self._attr_name = f"{self._brand} {self._serial_number} Daily Energy"

--- a/custom_components/emeraldenergy/sensor.py
+++ b/custom_components/emeraldenergy/sensor.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
     CONF_ENABLE_ENERGY_MONITORING,
 )
+from .helpers import CallbackDrivenEntityMixin, device_info_for
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ async def async_setup_entry(
     return True
 
 
-class EmeraldEnergySensor(SensorEntity):
+class EmeraldEnergySensor(CallbackDrivenEntityMixin, SensorEntity):
     """Representation of an Emerald HWS energy usage sensor."""
 
     def __init__(
@@ -101,13 +102,9 @@ class EmeraldEnergySensor(SensorEntity):
         self._attr_unique_id = f"{DOMAIN}_{hws_uuid}_daily_energy"
 
         # Set up device info for proper grouping with water heater
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, hws_uuid)},
-            "name": f"{self._brand} {self._serial_number}",
-            "manufacturer": self._brand,
-            "model": "Hot Water System",
-            "serial_number": self._serial_number,
-        }
+        self._attr_device_info = device_info_for(
+            hws_uuid, self._brand, self._serial_number
+        )
 
         # Register for updates with callback dispatcher
         callback_dispatcher.register_callback(self.update_callback)
@@ -119,22 +116,6 @@ class EmeraldEnergySensor(SensorEntity):
     def last_reset(self):
         """Return the time when the sensor was last reset (midnight)."""
         return self._last_reset
-
-    def update_callback(self):
-        """Schedules an update within HASS when data changes (module thread)."""
-        _LOGGER.debug(f"Energy sensor callback for {self._attr_name}")
-        if self.hass is None:
-            # The emerald_hws MQTT thread can fire callbacks before the entity
-            # is added to HASS (or after removal). schedule_update_ha_state is
-            # thread-safe, but with self.hass is None it would raise
-            # "'NoneType' object has no attribute 'create_task'".
-            _LOGGER.debug(
-                "Dropping callback for %s; hass not set (entity not added yet "
-                "or already removed)",
-                self._attr_name,
-            )
-            return
-        self.schedule_update_ha_state(True)
 
     def update_energy_value(self):
         """Update the energy value from the API."""
@@ -163,13 +144,3 @@ class EmeraldEnergySensor(SensorEntity):
         """Update the sensor state."""
         _LOGGER.debug(f"Updating energy sensor {self._attr_name}")
         self.update_energy_value()
-
-    async def async_update(self) -> None:
-        """Update the sensor state asynchronously."""
-        await self._hass.async_add_executor_job(self.update)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Clean up when entity is removed from Home Assistant."""
-        # Unregister from callback dispatcher
-        self._callback_dispatcher.unregister_callback(self.update_callback)
-        await super().async_will_remove_from_hass()

--- a/custom_components/emeraldenergy/water_heater.py
+++ b/custom_components/emeraldenergy/water_heater.py
@@ -25,6 +25,7 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import (
     DOMAIN,
 )
+from .helpers import CallbackDrivenEntityMixin, device_info_for
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ async def async_setup_entry(
     return True
 
 
-class EmeraldWaterHeater(WaterHeaterEntity):
+class EmeraldWaterHeater(CallbackDrivenEntityMixin, WaterHeaterEntity):
     """Representation of a water heater."""
 
     def __init__(self, hass, emerald_hws_instance, hws_uuid, callback_dispatcher):
@@ -113,13 +114,9 @@ class EmeraldWaterHeater(WaterHeaterEntity):
         self._name = f"{self._brand} {self._serial_number}"
         # Same identifiers as sensor.py's device_info so both entities group
         # under one device instead of two.
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, hws_uuid)},
-            "name": self._name,
-            "manufacturer": self._brand,
-            "model": "Hot Water System",
-            "serial_number": self._serial_number,
-        }
+        self._attr_device_info = device_info_for(
+            hws_uuid, self._brand, self._serial_number
+        )
         self._current_temperature = status.get("last_state").get("temp_current")
         self._target_temperature = status.get("last_state").get("temp_set")
         self._running = emerald_hws_instance.isOn(hws_uuid)
@@ -240,22 +237,6 @@ class EmeraldWaterHeater(WaterHeaterEntity):
             _call_hws, "turn off", self._emerald_hws.turnOff, self._hws_uuid
         )
 
-    def update_callback(self):
-        """Schedules an update within HASS (called from the module's thread)."""
-        _LOGGER.info("emeraldhws: callback called")
-        if self.hass is None:
-            # The emerald_hws MQTT thread can fire callbacks before the entity
-            # is added to HASS (or after removal). schedule_update_ha_state is
-            # thread-safe, but with self.hass is None it would raise
-            # "'NoneType' object has no attribute 'create_task'".
-            _LOGGER.debug(
-                "Dropping callback for %s; hass not set (entity not added yet "
-                "or already removed)",
-                self._name,
-            )
-            return
-        self.schedule_update_ha_state(True)
-
     def update(self):
         """Update with values from HWS."""
         _LOGGER.info("emeraldhws: updating internal state from module")
@@ -268,13 +249,3 @@ class EmeraldWaterHeater(WaterHeaterEntity):
             self._current_mode = self._emerald_hws.currentMode(self._hws_uuid)
             self._is_heating = self._emerald_hws.isHeating(self._hws_uuid)
         return
-
-    async def async_update(self) -> None:
-        """Update the water heater state."""
-        await self._hass.async_add_executor_job(self.update)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Clean up when entity is removed from Home Assistant."""
-        # Unregister from callback dispatcher
-        self._callback_dispatcher.unregister_callback(self.update_callback)
-        await super().async_will_remove_from_hass()

--- a/custom_components/emeraldenergy/water_heater.py
+++ b/custom_components/emeraldenergy/water_heater.py
@@ -104,9 +104,22 @@ class EmeraldWaterHeater(WaterHeaterEntity):
         self._callback_dispatcher = callback_dispatcher
         gi = emerald_hws_instance.getInfo(hws_uuid)
         status = emerald_hws_instance.getFullStatus(hws_uuid)
-        self._serial_number = gi.get("serial_number")
-        self._brand = gi.get("brand")
+        # Fall back rather than leaving these None: they land in the device
+        # registry, which is last-write-wins across this entity and the energy
+        # sensor sharing the same device -- a None from either would blank out
+        # a value the other successfully set.
+        self._serial_number = gi.get("serial_number") or hws_uuid
+        self._brand = gi.get("brand") or "Emerald"
         self._name = f"{self._brand} {self._serial_number}"
+        # Same identifiers as sensor.py's device_info so both entities group
+        # under one device instead of two.
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, hws_uuid)},
+            "name": self._name,
+            "manufacturer": self._brand,
+            "model": "Hot Water System",
+            "serial_number": self._serial_number,
+        }
         self._current_temperature = status.get("last_state").get("temp_current")
         self._target_temperature = status.get("last_state").get("temp_set")
         self._running = emerald_hws_instance.isOn(hws_uuid)


### PR DESCRIPTION
Split out of #240 per review feedback. **Stacked on #242** (fix/device-info-grouping) -- this branch is built on top of it, so the diff below includes that commit until #242 merges. The only new commit here is "Extract CallbackDrivenEntityMixin and device_info_for"; that's the actual content of this PR.

## Summary

No behavior change. `sensor.py` and `water_heater.py` reimplemented the same `update_callback`/`async_update`/`async_will_remove_from_hass` triplet identically (only logging text differed), and after #242 both build the same `device_info` dict shape from separate inline copies. Extracted both into `helpers.py`:

- `CallbackDrivenEntityMixin` -- the shared lifecycle. List it first in the entity's bases; `self._hass`/`self._callback_dispatcher` still set in `__init__` as before.
- `device_info_for(hws_uuid, brand, serial_number)` -- the shared device_info dict builder.

Applied to both entity classes that exist today (`EmeraldEnergySensor`, `EmeraldWaterHeater`). Deliberately scoped as a pure extraction -- no new entities, no new fields, no changed log levels beyond what moving the code required.

## Test plan

- `python3 -m py_compile` on all three changed files
- Manual read-through: diffed old vs. new method bodies line-for-line to confirm identical behavior (both `update_callback` implementations only differed in log message text, which the shared version keeps functionally equivalent)

## Summary by Sourcery

Centralize shared entity lifecycle and device metadata handling across the Emerald Energy entities.

Enhancements:
- Extract shared callback-driven entity lifecycle behavior and device metadata construction for the energy sensor and water heater.
- Ensure device metadata uses consistent fallback identifiers and manufacturer values when HWS information is incomplete.